### PR TITLE
feat: remove squash and fix crash detecting encrypted disks

### DIFF
--- a/disk/src/devices.rs
+++ b/disk/src/devices.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-
 use fancy_regex::Regex;
 use libparted::{Device, Disk};
 use tracing::info;
@@ -24,13 +23,14 @@ pub fn list_devices() -> impl Iterator<Item = Device<'static>> {
 pub fn is_root_device(d: &mut Device) -> Result<bool, PartitionError> {
     let root = find_root_mount_point()?;
 
-    for i in Disk::new(d)
-        .map_err(|e| PartitionError::OpenDisk {
-            path: "".to_string(),
-            err: e,
-        })?
-        .parts()
-    {
+    let disk = match Disk::new(d) {
+        Ok(disk) => disk,
+        Err(_) => {
+            return Ok(false);
+        }
+    };
+
+    for i in disk.parts() {
         if i.get_path()
             .map(|x| x.to_string_lossy() == root)
             .unwrap_or(false)

--- a/src/error.rs
+++ b/src/error.rs
@@ -282,6 +282,16 @@ impl From<&PostInstallationError> for DkError {
                     })
                 },
             },
+            PostInstallationError::Remove { source } => Self {
+                message: value.to_string(),
+                t: "Remove".to_string(),
+                data: {
+                    json!({
+                        "message": source.to_string(),
+                        "path": source.path,
+                    })
+                },
+            },
         }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -19,7 +19,7 @@ use disk::{
 };
 use install::{
     chroot::{escape_chroot, get_dir_fd},
-    mount::{remove_files_mounts, sync_disk, umount_root_path},
+    mount::{remove_files_mounts, remove_squash, sync_disk, umount_root_path},
     swap::{get_recommend_swap_size, swapoff},
     sync_and_reboot, DownloadType, InstallConfig, InstallConfigPrepare, InstallErr, SwapFile, User,
 };
@@ -754,6 +754,9 @@ fn safe_exit_env(root_fd: OwnedFd, tmp_dir: PathBuf) {
 
     sync_disk();
     swapoff(&tmp_dir).ok();
+
+    sync_disk();
+    remove_squash(&tmp_dir).ok();
 
     sync_disk();
     remove_files_mounts(&tmp_dir).ok();


### PR DESCRIPTION
This commit fixed the crash when detecting luks encrypted disks and add remove squash ability when installation is canceled or finished