### PR TITLE
fix(take_wake_lock.rs): inhibit most systemd session/power management

### DIFF
--- a/src/take_wake_lock.rs
+++ b/src/take_wake_lock.rs
@@ -7,7 +7,14 @@ pub async fn take_wake_lock(conn: &Connection) -> Result<Vec<OwnedFd>> {
     let proxy = ManagerProxy::new(conn).await?;
 
     let mut fds = vec![];
-    for i in [InhibitType::Sleep, InhibitType::Idle] {
+    for i in [
+        InhibitType::Sleep,
+        InhibitType::Idle,
+        InhibitType::HandlePowerKey,
+        InhibitType::HandleSuspendKey,
+        InhibitType::HandleHibernateKey,
+        InhibitType::HandleLidSwitch,
+    ] {
         let fd = proxy
             .inhibit(i, "Deploykit", "Deploykit Installing system", "block")
             .await?;


### PR DESCRIPTION
Except Shutdown, which would prevent user management of the LiveKit desktop
session (i.e., shutting down).
